### PR TITLE
Added encoding specification when saving as webp

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -84,7 +84,7 @@ class util:
                 metadata["0th"][inital_exif] = "{}:{}".format(x, json.dumps(extra_pnginfo[x]))
                 inital_exif -= 1
 
-        metadata["Exif"][piexif.ExifIFD.UserComment] = piexif.helper.UserComment.dump(formated_info)
+        metadata["Exif"][piexif.ExifIFD.UserComment] = piexif.helper.UserComment.dump(formated_info, "unicode")
 
         return piexif.dump(metadata)
 


### PR DESCRIPTION
1111でプロンプトを見た時に、日本語文字列がつぶれちゃってよめなかったみたいです。

メタデータに保存するときにエンコードを指定しないとデフォルトのASCIIで保存されるのが原因っぽかったので、エンコードの指定を追加しました。

修正前
![image](https://github.com/user-attachments/assets/9b806b3b-0243-41bd-bd64-53f5dee96032)

修正後
![image](https://github.com/user-attachments/assets/076dbb47-39d2-4cf8-aaf7-d46b72f58839)
