### PR TITLE
fixed: positive contents were saved in negative

### DIFF
--- a/D2_SendEagle.py
+++ b/D2_SendEagle.py
@@ -126,7 +126,7 @@ class D2_SendEagle:
             eagle_folder = eagle_folder,
             compression = compression,
             positive = self.__class__.get_prompt_value(positive, d2_pipe),
-            negative = self.__class__.get_prompt_value(positive, d2_pipe),
+            negative = self.__class__.get_prompt_value(negative, d2_pipe),
             memo_text = memo_text,
             prompt = prompt,
             extra_pnginfo = extra_pnginfo,


### PR DESCRIPTION
metadataのnagativeにpositiveの内容が保存されていたので、negativeの内容を保存するように修正しました。

修正前はこんな感じでしたの図
![image](https://github.com/user-attachments/assets/b6943767-fa2c-46a8-8fbf-fad8b78b943f)
